### PR TITLE
bump Docker / Kubernetes version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,20 @@ $ KUBECONFIG=secrets/admin.conf kubectl expose deploy nginx --port=80 --type Nod
 
 |  Name                    |  Default     |  Description                                                                      | Required |
 |:-------------------------|:-------------|:----------------------------------------------------------------------------------|:--------:|
-| `hcloud_token`              | ``           |API Token that will be generated through your hetzner cloud project https://console.hetzner.cloud/projects      | Yes      |
-| `master_count`                  | `1`           | Amount of masters that will be created                                         | No      |
-| `master_image`                 | `ubuntu-16.04`  | Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-16.04, debian-9,centos-7,fedora-27)                                     | No      |
-| `master_type`                   | `cx11`  | Machine type for more types have a look at https://www.hetzner.de/cloud                                   | No       |
-| `node_count`             | `1`  | Amount of nodes that will be created                                 | No       |
-| `node_image`                   | `ubuntu-16.04`         | Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-16.04, debian-9,centos-7,fedora-27)       |
-| `node_type`              | `cx11`          | Machine type for more types have a look at https://www.hetzner.de/cloud | No       |
-| `ssh_private_key`                    | `~/.ssh/id_ed25519`    | Private Key to access the machines       |
-| `ssh_public_key`          | `~/.ssh/id_ed25519.pub`          | Public Key to authorized the access for the machines                                                     | No       |
-| `docker_version`         | `18.06`          | Docker CE version that will be installed                                                     | No       |
-| `kubernetes_version`         | `1.12.2`          | Kubernetes version that will be installed                                                     | No       |
-| `core_dns`         | `false`          | Enables CoreDNS as Service Discovery                                                     | No       |
-| `calico_enabled`         | `false`          | Installs Calico Network Provider after the master comes up                                                    | No       |
+| `hcloud_token`        | ``                      |API Token that will be generated through your hetzner cloud project https://console.hetzner.cloud/projects                   | Yes |
+| `master_count`        | `1`                     | Amount of masters that will be created                                                                                      | No  |
+| `master_image`        | `ubuntu-16.04`          | Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-16.04, debian-9,centos-7,fedora-27) | No  |
+| `master_type`         | `cx11`                  | Machine type for more types have a look at https://www.hetzner.de/cloud                                                     | No  |
+| `node_count`          | `1`                     | Amount of nodes that will be created                                                                                        | No  |
+| `node_image`          | `ubuntu-16.04`          | Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-16.04, debian-9,centos-7,fedora-27) | No  |
+| `node_type`           | `cx11`                  | Machine type for more types have a look at https://www.hetzner.de/cloud                                                     | No  |
+| `ssh_private_key`     | `~/.ssh/id_ed25519`     | Private Key to access the machines                                                                                          | No  |
+| `ssh_public_key`      | `~/.ssh/id_ed25519.pub` | Public Key to authorized the access for the machines                                                                        | No  |
+| `docker_version`      | `19.03`                 | Docker CE version that will be installed                                                                                    | No  |
+| `kubernetes_version`  | `1.15.5`                | Kubernetes version that will be installed                                                                                   | No  |
+| `feature_gates`       | ``                      | Add your own Feature Gates for Kubeadm                                                                                      | No  |
+| `calico_enabled`      | `false`                 | Installs Calico Network Provider after the master comes up                                                                  | No  |
+
 All variables cloud be passed through `environment variables` or a `tfvars` file.
 
 An example for a `tfvars` file would be the following `terraform.tfvars`

--- a/files/10-kubeadm.conf
+++ b/files/10-kubeadm.conf
@@ -1,6 +1,6 @@
 [Service]
 Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --cgroup-driver=cgroupfs"
-Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true"
+Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests"
 Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"
 Environment="KUBELET_AUTHZ_ARGS=--authorization-mode=Webhook --client-ca-file=/etc/kubernetes/pki/ca.crt"

--- a/install-calico.tf
+++ b/install-calico.tf
@@ -7,13 +7,9 @@ resource "null_resource" "calico" {
   }
 
   provisioner "remote-exec" {
-    inline = [
-      "kubectl apply -f https://docs.projectcalico.org/v3.2/getting-started/kubernetes/installation/hosted/etcd.yaml",
-      "kubectl apply -f https://docs.projectcalico.org/v3.2/getting-started/kubernetes/installation/rbac.yaml",
-      "kubectl apply -f https://docs.projectcalico.org/v3.2/getting-started/kubernetes/installation/hosted/calico.yaml"
-    ]
+    inline = ["kubectl apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml"]
   }
 
-  depends_on = [hcloud_server.master]
+  depends_on = ["hcloud_server.master"]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "hcloud_server" "master" {
   }
 
   provisioner "remote-exec" {
-    inline = ["CORE_DNS=${var.core_dns} bash /root/master.sh"]
+    inline = ["FEATURE_GATES=${var.feature_gates} bash /root/master.sh"]
   }
 
   provisioner "local-exec" {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,12 +3,20 @@ set -eu
 DOCKER_VERSION=${DOCKER_VERSION:-}
 KUBERNETES_VERSION=${KUBERNETES_VERSION:-}
 
+
+waitforapt(){
+  while fuser /var/lib/apt/lists/lock >/dev/null 2>&1 ; do
+     echo "Waiting for other software managers to finish..." 
+     sleep 1
+  done
+}
+
 echo "
 Package: docker-ce
 Pin: version ${DOCKER_VERSION}.*
 Pin-Priority: 1000
 " > /etc/apt/preferences.d/docker-ce
-sleep 30
+waitforapt
 apt-get -qq update
 apt-get -qq install -y \
     apt-transport-https \
@@ -47,6 +55,7 @@ Pin: version ${KUBERNETES_VERSION}-*
 Pin-Priority: 1000
 " > /etc/apt/preferences.d/kubeadm
 
+waitforapt
 apt-get -qq update
 apt-get -qq install -y kubelet kubeadm
 

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -1,20 +1,13 @@
 #!/usr/bin/bash
 set -eu
 
-KUBERNETES_VERSION=${KUBERNETES_VERSION:-}
-CORE_DNS=${CORE_DNS:-}
-
-echo "
-Package: kubectl
-Pin: version ${KUBERNETES_VERSION}-*
-Pin-Priority: 1000
-" > /etc/apt/preferences.d/kubectl
-
-apt-get install -qq -y kubectl
-
 # Initialize Cluster
-kubeadm init --feature-gates CoreDNS="$CORE_DNS"
-
+if [[ -n "$FEATURE_GATES" ]]
+then
+  kubeadm init --pod-network-cidr=192.168.0.0/16 --feature-gates $FEATURE_GATES
+else
+  kubeadm init  --pod-network-cidr=192.168.0.0/16
+fi
 systemctl enable docker kubelet
 
 # used to join nodes to the cluster

--- a/variables.tf
+++ b/variables.tf
@@ -38,15 +38,16 @@ variable "ssh_public_key" {
 }
 
 variable "docker_version" {
-  default = "18.06"
+  default = "19.03"
 }
 
 variable "kubernetes_version" {
-  default = "1.12.2"
+  default = "1.15.5"
 }
 
-variable "core_dns" {
-  default = false
+variable "feature_gates" {
+  description = "Add Feature Gates e.g. 'DynamicKubeletConfig=true'"
+  default     = ""
 }
 
 variable "calico_enabled" {


### PR DESCRIPTION
Updates to Kubernetes 1.15 and Docker 19.03
Since Core DNS is a default feature, make general feature gates available. 

Lastly, tweaked the bootstrap script to make it more resilient