### PR TITLE
bump versions and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ $ terraform apply
 $ terraform init
 $ terraform apply
 $ KUBECONFIG=secrets/admin.conf kubectl get nodes
-$ KUBECONFIG=secrets/admin.conf kubectl apply -f https://docs.projectcalico.org/v3.2/getting-started/kubernetes/installation/hosted/etcd.yaml
-$ KUBECONFIG=secrets/admin.conf kubectl apply -f https://docs.projectcalico.org/v3.2/getting-started/kubernetes/installation/rbac.yaml
-$ KUBECONFIG=secrets/admin.conf kubectl apply -f https://docs.projectcalico.org/v3.2/getting-started/kubernetes/installation/hosted/calico.yaml
+$ KUBECONFIG=secrets/admin.conf kubectl apply -f https://docs.projectcalico.org/archive/v3.15/manifests/calico.yaml
 $ KUBECONFIG=secrets/admin.conf kubectl get pods --namespace=kube-system -o wide
 $ KUBECONFIG=secrets/admin.conf kubectl run nginx --image=nginx
 $ KUBECONFIG=secrets/admin.conf kubectl expose deploy nginx --port=80 --type NodePort
@@ -30,15 +28,15 @@ $ KUBECONFIG=secrets/admin.conf kubectl expose deploy nginx --port=80 --type Nod
 |:-------------------------|:-------------|:----------------------------------------------------------------------------------|:--------:|
 | `hcloud_token`        | ``                      |API Token that will be generated through your hetzner cloud project https://console.hetzner.cloud/projects                   | Yes |
 | `master_count`        | `1`                     | Amount of masters that will be created                                                                                      | No  |
-| `master_image`        | `ubuntu-16.04`          | Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-16.04, debian-9,centos-7,fedora-27) | No  |
+| `master_image`        | `ubuntu-20.04`          | Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-20.04, ubuntu-18.04)                | No  |
 | `master_type`         | `cx11`                  | Machine type for more types have a look at https://www.hetzner.de/cloud                                                     | No  |
 | `node_count`          | `1`                     | Amount of nodes that will be created                                                                                        | No  |
-| `node_image`          | `ubuntu-16.04`          | Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-16.04, debian-9,centos-7,fedora-27) | No  |
+| `node_image`          | `ubuntu-20.04`          | Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-20.04, ubuntu-18.04)                | No  |
 | `node_type`           | `cx11`                  | Machine type for more types have a look at https://www.hetzner.de/cloud                                                     | No  |
 | `ssh_private_key`     | `~/.ssh/id_ed25519`     | Private Key to access the machines                                                                                          | No  |
 | `ssh_public_key`      | `~/.ssh/id_ed25519.pub` | Public Key to authorized the access for the machines                                                                        | No  |
 | `docker_version`      | `19.03`                 | Docker CE version that will be installed                                                                                    | No  |
-| `kubernetes_version`  | `1.15.5`                | Kubernetes version that will be installed                                                                                   | No  |
+| `kubernetes_version`  | `1.18.6`                | Kubernetes version that will be installed                                                                                   | No  |
 | `feature_gates`       | ``                      | Add your own Feature Gates for Kubeadm                                                                                      | No  |
 | `calico_enabled`      | `false`                 | Installs Calico Network Provider after the master comes up                                                                  | No  |
 
@@ -53,8 +51,8 @@ master_type = "cx21"
 master_count = 1
 node_type = "cx31"
 node_count = 2
-kubernetes_version = "1.9.6"
-docker_version = "17.03"
+kubernetes_version = "1.18.6"
+docker_version = "19.03"
 ```
 
 Or passing directly via Arguments
@@ -62,8 +60,8 @@ Or passing directly via Arguments
 ```console
 $ terraform apply \
   -var hcloud_token="<yourgeneratedtoken>" \
-  -var docker_version=17.03 \
-  -var kubernetes_version=1.9.6 \
+  -var docker_version=19.03 \
+  -var kubernetes_version=1.18.6 \
   -var master_type=cx21 \
   -var master_count=1 \
   -var node_type=cx31 \
@@ -80,5 +78,5 @@ Please use the [issue tracker](https://github.com/solidnerd/terraform-k8s-hcloud
 
 **Tested with**
 
-- Terraform [v0.12.8](https://github.com/hashicorp/terraform/tree/v0.12.8)
-- provider.hcloud [v1.12.0](https://github.com/terraform-providers/terraform-provider-hcloud)
+- Terraform [v0.12.24](https://github.com/hashicorp/terraform/tree/v0.12.24)
+- provider.hcloud [v1.19.0](https://github.com/terraform-providers/terraform-provider-hcloud)

--- a/files/10-kubeadm.conf
+++ b/files/10-kubeadm.conf
@@ -2,7 +2,7 @@
 Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --cgroup-driver=cgroupfs"
 Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests"
 Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
-Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"
+Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local --resolv-conf=/run/systemd/resolve/resolv.conf"
 Environment="KUBELET_AUTHZ_ARGS=--authorization-mode=Webhook --client-ca-file=/etc/kubernetes/pki/ca.crt"
 Environment="KUBELET_CERTIFICATE_ARGS=--rotate-certificates=true --cert-dir=/var/lib/kubelet/pki"
 ExecStart=

--- a/install-calico.tf
+++ b/install-calico.tf
@@ -7,7 +7,7 @@ resource "null_resource" "calico" {
   }
 
   provisioner "remote-exec" {
-    inline = ["kubectl apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml"]
+    inline = ["kubectl apply -f https://docs.projectcalico.org/archive/v3.15/manifests/calico.yaml"]
   }
 
   depends_on = ["hcloud_server.master"]

--- a/variables.tf
+++ b/variables.tf
@@ -5,8 +5,8 @@ variable "master_count" {
 }
 
 variable "master_image" {
-  description = "Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-16.04, debian-9,centos-7,fedora-27)"
-  default     = "ubuntu-16.04"
+  description = "Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-20.04, ubuntu-18.04)"
+  default     = "ubuntu-20.04"
 }
 
 variable "master_type" {
@@ -18,8 +18,8 @@ variable "node_count" {
 }
 
 variable "node_image" {
-  description = "Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-16.04, debian-9,centos-7,fedora-27)"
-  default     = "ubuntu-16.04"
+  description = "Predefined Image that will be used to spin up the machines (Currently supported: ubuntu-20.04, ubuntu-18.04)"
+  default     = "ubuntu-20.04"
 }
 
 variable "node_type" {
@@ -42,7 +42,7 @@ variable "docker_version" {
 }
 
 variable "kubernetes_version" {
-  default = "1.15.5"
+  default = "1.18.6"
 }
 
 variable "feature_gates" {


### PR DESCRIPTION
As discussed [in issue 23](https://github.com/solidnerd/terraform-k8s-hcloud/issues/23) this PR contains a version bump.
Before adding more features the project should use current software versions.

I updated the default values for:
Kubernetes to `v1.18.6`
Master and node images to `ubuntu-20.04`
Calico to `v3.15`

I also had to add the ` --resolv-conf` flag as a kubelet argument to fix a loop in the dns configuration of the coredns pods. Newer Ubuntu versions use `systemd-resolved` and the path to the `resolv.conf` has to be specified (see [here](https://coredns.io/plugins/loop/#troubleshooting-loops-in-kubernetes-clusters)).

Furthermore I removed `ubuntu-16.04`, `debian-9`, `centos-7` and `fedora-27` from the list of supported images and only listed `ubuntu-20.04`and `ubuntu-18.04` because the bootstrap of the cluster fails with other images. The bootstrap script is also quite Ubuntu specific so I think Ubuntu should be the focus. Maybe debian could be added at a later date.
I tested the deployment with `ubuntu-20.04`and `ubuntu-18.04`.