### PR TITLE
add hcloud csi driver volume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ KUBECONFIG=secrets/admin.conf kubectl expose deploy nginx --port=80 --type Nod
 | `kubernetes_version`  | `1.18.6`                | Kubernetes version that will be installed                                                                                   | No  |
 | `feature_gates`       | ``                      | Add your own Feature Gates for Kubeadm                                                                                      | No  |
 | `calico_enabled`      | `false`                 | Installs Calico Network Provider after the master comes up                                                                  | No  |
+| `csi_driver_enabled`  | `false`	                | Installs [hcloud-csi driver](https://github.com/hetznercloud/csi-driver) for persistent volume support                      | No  |
 
 All variables cloud be passed through `environment variables` or a `tfvars` file.
 

--- a/install-hcloud-csi.tf
+++ b/install-hcloud-csi.tf
@@ -1,0 +1,20 @@
+resource "null_resource" "hcloud-csi" {
+  count = var.csi_driver_enabled ? 1 : 0
+
+  connection {
+    host        = hcloud_server.master.0.ipv4_address
+    private_key = file(var.ssh_private_key)
+  }
+
+  provisioner "file" {
+    source      = "scripts/install-hcloud-csi.sh"
+    destination = "/root/install-hcloud-csi.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = ["HCLOUD_TOKEN=${var.hcloud_token} bash /root/install-hcloud-csi.sh"]
+  }
+
+  depends_on = [hcloud_server.master]
+}
+

--- a/scripts/install-hcloud-csi.sh
+++ b/scripts/install-hcloud-csi.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bas
+set -eu
+
+#create secret with hcloud token for hcloud-csi driver
+kubectl -n kube-system create secret generic hcloud-csi --from-literal=token=$HCLOUD_TOKEN --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.4.0/deploy/kubernetes/hcloud-csi.yml

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,6 @@ variable "calico_enabled" {
   default = false
 }
 
+variable "csi_driver_enabled" {
+  default = false
+}


### PR DESCRIPTION
This PR adds support for persistent volumes in kubernetes using the [csi-driver](https://github.com/hetznercloud/csi-driver). Feature mentioned [here](https://github.com/solidnerd/terraform-k8s-hcloud/issues/23).

To test set `csi_driver_enabled = true` and use the following snippet*:

```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: csi-pvc
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
  storageClassName: hcloud-volumes
---
kind: Pod
apiVersion: v1
metadata:
  name: my-csi-app
spec:
  containers:
    - name: my-frontend
      image: busybox
      volumeMounts:
      - mountPath: "/data"
        name: my-csi-volume
      command: [ "sleep", "1000000" ]
  volumes:
    - name: my-csi-volume
      persistentVolumeClaim:
        claimName: csi-pvc
EOF
```
*from [here](https://github.com/hetznercloud/csi-driver)

Then monitor the pod, the pvc and the volumes in hcloud dashboard.