### PR TITLE
Quoted references are deprecated

### DIFF
--- a/install-calico.tf
+++ b/install-calico.tf
@@ -10,6 +10,6 @@ resource "null_resource" "calico" {
     inline = ["kubectl apply -f https://docs.projectcalico.org/archive/v3.15/manifests/calico.yaml"]
   }
 
-  depends_on = ["hcloud_server.master"]
+  depends_on = [hcloud_server.master]
 }
 


### PR DESCRIPTION
Addressing this:

Warning: Quoted references are deprecated
  on install-calico.tf line 13, in resource "null_resource" "calico":
  13:   depends_on = ["hcloud_server.master"]